### PR TITLE
Add visf atlas

### DIFF
--- a/atlases/human.json
+++ b/atlases/human.json
@@ -28,6 +28,7 @@
 		"https://identifiers.org/neurovault.image:23262",
 		"https://doi.org/10.1016/j.jneumeth.2020.108983/mni152",
 		"minds/core/parcellationatlas/v1.0.0/887da8eb4c36d944ef626ed5293db3ef",
-		"minds/core/parcellationatlas/v1.0.0/f2b1ac621421708c1bef422bb5058456"
+		"minds/core/parcellationatlas/v1.0.0/f2b1ac621421708c1bef422bb5058456",
+		"minds/core/parcellationatlas/v1.0.0/d41d8cd98f00b204e9800998ecf8427e"
 	]
 }

--- a/maps/fsaverage-visfAtlas-labelled.json
+++ b/maps/fsaverage-visfAtlas-labelled.json
@@ -18,231 +18,231 @@
 		}
 	],
 	"indices": {
-		"mFus-faces - left hemisphere": [
+		"lh_mFus_faces": [
 			{
 				"volume": 0,
 				"fragment": "left hemisphere",
 				"label": 1
 			}
 		],
-		"pFus-faces - left hemisphere": [
+		"lh_pFus_faces": [
 			{
 				"volume": 0,
 				"fragment": "left hemisphere",
 				"label": 2
 			}
 		],
-		"IOG-faces - left hemisphere": [
+		"lh_IOG_faces": [
 			{
 				"volume": 0,
 				"fragment": "left hemisphere",
 				"label": 3
 			}
 		],
-		"OTS-bodies - left hemisphere": [
+		"lh_OTS_bodies": [
 			{
 				"volume": 0,
 				"fragment": "left hemisphere",
 				"label": 4
 			}
 		],
-		"ITG-bodies - left hemisphere": [
+		"lh_ITG_bodies": [
 			{
 				"volume": 0,
 				"fragment": "left hemisphere",
 				"label": 5
 			}
 		],
-		"MTG-bodies - left hemisphere": [
+		"lh_MTG_bodies": [
 			{
 				"volume": 0,
 				"fragment": "left hemisphere",
 				"label": 6
 			}
 		],
-		"LOS-bodies - left hemisphere": [
+		"lh_LOS_bodies": [
 			{
 				"volume": 0,
 				"fragment": "left hemisphere",
 				"label": 7
 			}
 		],
-		"pOTS-characters - left hemisphere": [
+		"lh_pOTS_characters": [
 			{
 				"volume": 0,
 				"fragment": "left hemisphere",
 				"label": 8
 			}
 		],
-		"IOS-characters - left hemisphere": [
+		"lh_IOS_haracters": [
 			{
 				"volume": 0,
 				"fragment": "left hemisphere",
 				"label": 9
 			}
 		],
-		"CoS-places - left hemisphere": [
+		"lh_CoS_places": [
 			{
 				"volume": 0,
 				"fragment": "left hemisphere",
 				"label": 10
 			}
 		],
-		"hMT - left hemisphere": [
+		"lh_hMT": [
 			{
 				"volume": 0,
 				"fragment": "left hemisphere",
 				"label": 11
 			}
 		],
-		"v1d - left hemisphere": [
+		"lh_v1d": [
 			{
 				"volume": 0,
 				"fragment": "left hemisphere",
 				"label": 12
 			}
 		],
-		"v2d - left hemisphere": [
+		"lh_v2d": [
 			{
 				"volume": 0,
 				"fragment": "left hemisphere",
 				"label": 13
 			}
 		],
-		"v3d - left hemisphere": [
+		"lh_v3d": [
 			{
 				"volume": 0,
 				"fragment": "left hemisphere",
 				"label": 14
 			}
 		],
-		"v1v - left hemisphere": [
+		"lh_v1v": [
 			{
 				"volume": 0,
 				"fragment": "left hemisphere",
 				"label": 15
 			}
 		],
-		"v2v - left hemisphere": [
+		"lh_v2v": [
 			{
 				"volume": 0,
 				"fragment": "left hemisphere",
 				"label": 16
 			}
 		],
-		"v3v - left hemisphere": [
+		"lh_v3v": [
 			{
 				"volume": 0,
 				"fragment": "left hemisphere",
 				"label": 17
 			}
 		],
-		"mFus-faces - right hemisphere": [
+		"rh_mFus_faces": [
 			{
 				"volume": 0,
 				"fragment": "right hemisphere",
 				"label": 1
 			}
 		],
-		"pFus-faces - right hemisphere": [
+		"rh_pFus_faces": [
 			{
 				"volume": 0,
 				"fragment": "right hemisphere",
 				"label": 2
 			}
 		],
-		"IOG-faces - right hemisphere": [
+		"rh_IOG_faces": [
 			{
 				"volume": 0,
 				"fragment": "right hemisphere",
 				"label": 3
 			}
 		],
-		"OTS-bodies - right hemisphere": [
+		"rh_OTS_bodies": [
 			{
 				"volume": 0,
 				"fragment": "right hemisphere",
 				"label": 4
 			}
 		],
-		"ITG-bodies - right hemisphere": [
+		"rh_ITG_bodies": [
 			{
 				"volume": 0,
 				"fragment": "right hemisphere",
 				"label": 5
 			}
 		],
-		"MTG-bodies - right hemisphere": [
+		"rh_MTG_bodies": [
 			{
 				"volume": 0,
 				"fragment": "right hemisphere",
 				"label": 6
 			}
 		],
-		"LOS-bodies - right hemisphere": [
+		"rh_LOS_bodies": [
 			{
 				"volume": 0,
 				"fragment": "right hemisphere",
 				"label": 7
 			}
 		],
-		"CoS-places - right hemisphere": [
+		"rh_CoS_places": [
 			{
 				"volume": 0,
 				"fragment": "right hemisphere",
 				"label": 8
 			}
 		],
-		"TOS-places - right hemisphere": [
+		"rh_TOS_places": [
 			{
 				"volume": 0,
 				"fragment": "right hemisphere",
 				"label": 9
 			}
 		],
-		"hMT - right hemisphere": [
+		"rh_hMT": [
 			{
 				"volume": 0,
 				"fragment": "right hemisphere",
 				"label": 10
 			}
 		],
-		"v1d - right hemisphere": [
+		"rh_v1d": [
 			{
 				"volume": 0,
 				"fragment": "right hemisphere",
 				"label": 11
 			}
 		],
-		"v2d - right hemisphere": [
+		"rh_v2d": [
 			{
 				"volume": 0,
 				"fragment": "right hemisphere",
 				"label": 12
 			}
 		],
-		"v3d - right hemisphere": [
+		"rh_v3d": [
 			{
 				"volume": 0,
 				"fragment": "right hemisphere",
 				"label": 13
 			}
 		],
-		"v1v - right hemisphere": [
+		"rh_v1v": [
 			{
 				"volume": 0,
 				"fragment": "right hemisphere",
 				"label": 14
 			}
 		],
-		"v2v - right hemisphere": [
+		"rh_v2v": [
 			{
 				"volume": 0,
 				"fragment": "right hemisphere",
 				"label": 15
 			}
 		],
-		"v3v - right hemisphere": [
+		"rh_v3v": [
 			{
 				"volume": 0,
 				"fragment": "right hemisphere",

--- a/maps/fsaverage-visfAtlas-labelled.json
+++ b/maps/fsaverage-visfAtlas-labelled.json
@@ -13,6 +13,10 @@
 				"zip/freesurfer-annot": {
 					"left hemisphere": "https://download.brainvoyager.com/data/visfAtlas.zip visfAtlas/FreeSurfer/lh.visfAtlas.annot",
 					"right hemisphere": "https://download.brainvoyager.com/data/visfAtlas.zip visfAtlas/FreeSurfer/rh.visfAtlas.annot"
+				},
+				"freesurfer-annot": {
+					"left hemisphere": "https://data-proxy.ebrains.eu/api/v1/buckets/reference-atlas-data/temp/lh.visfAtlas.annot",
+					"right hemisphere": "https://data-proxy.ebrains.eu/api/v1/buckets/reference-atlas-data/temp/lh.visfAtlas.annot"
 				}
 			}
 		}

--- a/maps/fsaverage-visfAtlas-labelled.json
+++ b/maps/fsaverage-visfAtlas-labelled.json
@@ -1,0 +1,253 @@
+{
+	"@type": "siibra/map/v0.0.1",
+	"space": {
+		"@id": "minds/core/referencespace/v1.0.0/tmp-fsaverage"
+	},
+	"parcellation": {
+		"@id": "minds/core/parcellationatlas/v1.0.0/d41d8cd98f00b204e9800998ecf8427e"
+	},
+	"volumes": [
+		{
+			"@type": "siibra/volume/v0.0.1",
+			"providers": {
+				"zip/freesurfer-annot": {
+					"left hemisphere": "https://download.brainvoyager.com/data/visfAtlas.zip visfAtlas/FreeSurfer/lh.visfAtlas.annot",
+					"right hemisphere": "https://download.brainvoyager.com/data/visfAtlas.zip visfAtlas/FreeSurfer/rh.visfAtlas.annot"
+				}
+			}
+		}
+	],
+	"indices": {
+		"mFus-faces - left hemisphere": [
+			{
+				"volume": 0,
+				"fragment": "left hemisphere",
+				"label": 1
+			}
+		],
+		"pFus-faces - left hemisphere": [
+			{
+				"volume": 0,
+				"fragment": "left hemisphere",
+				"label": 2
+			}
+		],
+		"IOG-faces - left hemisphere": [
+			{
+				"volume": 0,
+				"fragment": "left hemisphere",
+				"label": 3
+			}
+		],
+		"OTS-bodies - left hemisphere": [
+			{
+				"volume": 0,
+				"fragment": "left hemisphere",
+				"label": 4
+			}
+		],
+		"ITG-bodies - left hemisphere": [
+			{
+				"volume": 0,
+				"fragment": "left hemisphere",
+				"label": 5
+			}
+		],
+		"MTG-bodies - left hemisphere": [
+			{
+				"volume": 0,
+				"fragment": "left hemisphere",
+				"label": 6
+			}
+		],
+		"LOS-bodies - left hemisphere": [
+			{
+				"volume": 0,
+				"fragment": "left hemisphere",
+				"label": 7
+			}
+		],
+		"pOTS-characters - left hemisphere": [
+			{
+				"volume": 0,
+				"fragment": "left hemisphere",
+				"label": 8
+			}
+		],
+		"IOS-characters - left hemisphere": [
+			{
+				"volume": 0,
+				"fragment": "left hemisphere",
+				"label": 9
+			}
+		],
+		"CoS-places - left hemisphere": [
+			{
+				"volume": 0,
+				"fragment": "left hemisphere",
+				"label": 10
+			}
+		],
+		"hMT - left hemisphere": [
+			{
+				"volume": 0,
+				"fragment": "left hemisphere",
+				"label": 11
+			}
+		],
+		"v1d - left hemisphere": [
+			{
+				"volume": 0,
+				"fragment": "left hemisphere",
+				"label": 12
+			}
+		],
+		"v2d - left hemisphere": [
+			{
+				"volume": 0,
+				"fragment": "left hemisphere",
+				"label": 13
+			}
+		],
+		"v3d - left hemisphere": [
+			{
+				"volume": 0,
+				"fragment": "left hemisphere",
+				"label": 14
+			}
+		],
+		"v1v - left hemisphere": [
+			{
+				"volume": 0,
+				"fragment": "left hemisphere",
+				"label": 15
+			}
+		],
+		"v2v - left hemisphere": [
+			{
+				"volume": 0,
+				"fragment": "left hemisphere",
+				"label": 16
+			}
+		],
+		"v3v - left hemisphere": [
+			{
+				"volume": 0,
+				"fragment": "left hemisphere",
+				"label": 17
+			}
+		],
+		"mFus-faces - right hemisphere": [
+			{
+				"volume": 0,
+				"fragment": "right hemisphere",
+				"label": 1
+			}
+		],
+		"pFus-faces - right hemisphere": [
+			{
+				"volume": 0,
+				"fragment": "right hemisphere",
+				"label": 2
+			}
+		],
+		"IOG-faces - right hemisphere": [
+			{
+				"volume": 0,
+				"fragment": "right hemisphere",
+				"label": 3
+			}
+		],
+		"OTS-bodies - right hemisphere": [
+			{
+				"volume": 0,
+				"fragment": "right hemisphere",
+				"label": 4
+			}
+		],
+		"ITG-bodies - right hemisphere": [
+			{
+				"volume": 0,
+				"fragment": "right hemisphere",
+				"label": 5
+			}
+		],
+		"MTG-bodies - right hemisphere": [
+			{
+				"volume": 0,
+				"fragment": "right hemisphere",
+				"label": 6
+			}
+		],
+		"LOS-bodies - right hemisphere": [
+			{
+				"volume": 0,
+				"fragment": "right hemisphere",
+				"label": 7
+			}
+		],
+		"CoS-places - right hemisphere": [
+			{
+				"volume": 0,
+				"fragment": "right hemisphere",
+				"label": 8
+			}
+		],
+		"TOS-places - right hemisphere": [
+			{
+				"volume": 0,
+				"fragment": "right hemisphere",
+				"label": 9
+			}
+		],
+		"hMT - right hemisphere": [
+			{
+				"volume": 0,
+				"fragment": "right hemisphere",
+				"label": 10
+			}
+		],
+		"v1d - right hemisphere": [
+			{
+				"volume": 0,
+				"fragment": "right hemisphere",
+				"label": 11
+			}
+		],
+		"v2d - right hemisphere": [
+			{
+				"volume": 0,
+				"fragment": "right hemisphere",
+				"label": 12
+			}
+		],
+		"v3d - right hemisphere": [
+			{
+				"volume": 0,
+				"fragment": "right hemisphere",
+				"label": 13
+			}
+		],
+		"v1v - right hemisphere": [
+			{
+				"volume": 0,
+				"fragment": "right hemisphere",
+				"label": 14
+			}
+		],
+		"v2v - right hemisphere": [
+			{
+				"volume": 0,
+				"fragment": "right hemisphere",
+				"label": 15
+			}
+		],
+		"v3v - right hemisphere": [
+			{
+				"volume": 0,
+				"fragment": "right hemisphere",
+				"label": 16
+			}
+		]
+	}
+}

--- a/maps/mni152-visfAtlas-labelled.json
+++ b/maps/mni152-visfAtlas-labelled.json
@@ -1,0 +1,217 @@
+{
+	"space": {
+		"@id": "minds/core/referencespace/v1.0.0/dafcffc5-4826-4bf1-8ff6-46b8a31ff8e2"
+	},
+	"parcellation": {
+		"@id": "minds/core/parcellationatlas/v1.0.0/d41d8cd98f00b204e9800998ecf8427e"
+	},
+	"volumes": [
+		{
+			"@type": "siibra/volume/v0.0.1",
+			"providers": {
+				"zip/nii": "https://download.brainvoyager.com/data/visfAtlas.zip visfAtlas_MNI152_volume.nii.gz"
+			}
+		}
+	],
+	"@type": "siibra/map/v0.0.1",
+	"indices": {
+		"lh_mFus_faces": [
+			{
+				"volume": 0,
+				"label": 1
+			}
+		],
+		"lh_pFus_faces": [
+			{
+				"volume": 0,
+				"label": 2
+			}
+		],
+		"lh_IOG_faces": [
+			{
+				"volume": 0,
+				"label": 3
+			}
+		],
+		"lh_OTS_bodies": [
+			{
+				"volume": 0,
+				"label": 4
+			}
+		],
+		"lh_ITG_bodies": [
+			{
+				"volume": 0,
+				"label": 5
+			}
+		],
+		"lh_MTG_bodies": [
+			{
+				"volume": 0,
+				"label": 6
+			}
+		],
+		"lh_LOS_bodies": [
+			{
+				"volume": 0,
+				"label": 7
+			}
+		],
+		"lh_pOTS_characters": [
+			{
+				"volume": 0,
+				"label": 8
+			}
+		],
+		"lh_IOS_haracters": [
+			{
+				"volume": 0,
+				"label": 9
+			}
+		],
+		"lh_CoS_places": [
+			{
+				"volume": 0,
+				"label": 10
+			}
+		],
+		"lh_hMT_motion": [
+			{
+				"volume": 0,
+				"label": 11
+			}
+		],
+		"lh_v1d_retinotopic": [
+			{
+				"volume": 0,
+				"label": 12
+			}
+		],
+		"lh_v2d_retinotopic": [
+			{
+				"volume": 0,
+				"label": 13
+			}
+		],
+		"lh_v3d_retinotopic": [
+			{
+				"volume": 0,
+				"label": 14
+			}
+		],
+		"lh_v1v_retinotopic": [
+			{
+				"volume": 0,
+				"label": 15
+			}
+		],
+		"lh_v2v_retinotopic": [
+			{
+				"volume": 0,
+				"label": 16
+			}
+		],
+		"lh_v3v_retinotopic": [
+			{
+				"volume": 0,
+				"label": 17
+			}
+		],
+		"rh_mFus_faces": [
+			{
+				"volume": 0,
+				"label": 18
+			}
+		],
+		"rh_pFus_faces ": [
+			{
+				"volume": 0,
+				"label": 19
+			}
+		],
+		"rh_IOG_faces": [
+			{
+				"volume": 0,
+				"label": 20
+			}
+		],
+		"rh_OTS_bodies": [
+			{
+				"volume": 0,
+				"label": 21
+			}
+		],
+		"rh_ITG_bodies": [
+			{
+				"volume": 0,
+				"label": 22
+			}
+		],
+		"rh_MTG_bodies": [
+			{
+				"volume": 0,
+				"label": 23
+			}
+		],
+		"rh_LOS_bodies": [
+			{
+				"volume": 0,
+				"label": 24
+			}
+		],
+		"rh_CoS_places": [
+			{
+				"volume": 0,
+				"label": 25
+			}
+		],
+		"rh_TOS_places": [
+			{
+				"volume": 0,
+				"label": 26
+			}
+		],
+		"rh_hMT_motion": [
+			{
+				"volume": 0,
+				"label": 27
+			}
+		],
+		"rh_v1d_retinotopic": [
+			{
+				"volume": 0,
+				"label": 28
+			}
+		],
+		"rh_v2d_retinotopic": [
+			{
+				"volume": 0,
+				"label": 29
+			}
+		],
+		"rh_v3d_retinotopic": [
+			{
+				"volume": 0,
+				"label": 30
+			}
+		],
+		"rh_v1v_retinotopic": [
+			{
+				"volume": 0,
+				"label": 31
+			}
+		],
+		"rh_v2v_retinotopic": [
+			{
+				"volume": 0,
+				"label": 32
+			}
+		],
+		"rh_v3v_retinotopic": [
+			{
+				"volume": 0,
+				"label": 33
+			}
+		]
+	}
+}

--- a/maps/mni152-visfAtlas-labelled.json
+++ b/maps/mni152-visfAtlas-labelled.json
@@ -9,7 +9,7 @@
 		{
 			"@type": "siibra/volume/v0.0.1",
 			"providers": {
-				"zip/nii": "https://download.brainvoyager.com/data/visfAtlas.zip visfAtlas_MNI152_volume.nii.gz"
+				"zip/nii": "https://download.brainvoyager.com/data/visfAtlas.zip nifti_volume/visfAtlas_MNI152_volume.nii.gz"
 			}
 		}
 	],

--- a/maps/mni152-visfAtlas-labelled.json
+++ b/maps/mni152-visfAtlas-labelled.json
@@ -9,7 +9,8 @@
 		{
 			"@type": "siibra/volume/v0.0.1",
 			"providers": {
-				"zip/nii": "https://download.brainvoyager.com/data/visfAtlas.zip nifti_volume/visfAtlas_MNI152_volume.nii.gz"
+				"zip/nii": "https://download.brainvoyager.com/data/visfAtlas.zip nifti_volume/visfAtlas_MNI152_volume.nii.gz",
+				"neuroglancer/precomputed": "https://neuroglancer.humanbrainproject.eu/precomputed/data-repo-ng-bot/siibra-config/20240423-ingest-visfatlas/visfAtlas_MNI152_volume"
 			}
 		}
 	],

--- a/parcellations/visfAtlas.json
+++ b/parcellations/visfAtlas.json
@@ -1,7 +1,7 @@
 {
 	"@id": "minds/core/parcellationatlas/v1.0.0/d41d8cd98f00b204e9800998ecf8427e",
 	"@type": "siibra/parcellation/v0.0.1",
-	"name": "A Probabilistic Functional Atlas of Human Occipito-Temporal Visual Cortex",
+	"name": "[PRERELEASE] A Probabilistic Functional Atlas of Human Occipito-Temporal Visual Cortex",
 	"shortName": "visfAtlas",
 	"modality": "HIP-HOP",
 	"species": "homo sapiens",

--- a/parcellations/visfAtlas.json
+++ b/parcellations/visfAtlas.json
@@ -1,7 +1,7 @@
 {
 	"@id": "minds/core/parcellationatlas/v1.0.0/d41d8cd98f00b204e9800998ecf8427e",
 	"@type": "siibra/parcellation/v0.0.1",
-	"name": "",
+	"name": "A Probabilistic Functional Atlas of Human Occipito-Temporal Visual Cortex",
 	"shortName": "visfAtlas",
 	"modality": "HIP-HOP",
 	"species": "homo sapiens",

--- a/parcellations/visfAtlas.json
+++ b/parcellations/visfAtlas.json
@@ -1,0 +1,158 @@
+{
+	"@id": "minds/core/parcellationatlas/v1.0.0/d41d8cd98f00b204e9800998ecf8427e",
+	"@type": "siibra/parcellation/v0.0.1",
+	"name": "",
+	"shortName": "visfAtlas",
+	"modality": "HIP-HOP",
+	"species": "homo sapiens",
+	"description": "",
+	"publications": [
+		{
+			"name": "A Probabilistic Functional Atlas of Human Occipito-Temporal Visual Cortex",
+			"url": "https://doi.org/10.1093/cercor/bhaa246",
+			"authors": [
+				"Mona Rosenke",
+				"Rick van Hoof",
+				"Job van den Hurk",
+				"Kalanit Grill-Spector",
+				"Rainer Goebel"
+			],
+			"description": "Human visual cortex contains many retinotopic and category- specific regions. These brain regions have been the focus of a large body of functional magnetic resonance imaging research, significantly expanding our understanding of visual processing. As studying these regions requires accurate localization of their cortical location, researchers perform functional localizer scans to identify these regions in each individual. However, it is not always possible to conduct these localizer scans. Here, we developed and validated a functional region of interest (ROI) atlas of early visual and category-selective regions in human ventral and lateral occipito-temporal cortex. Results show that for the majority of functionally defined ROIs, cortex-based alignment results in lower between- subject variability compared to nonlinear volumetric alignment. Furthermore, we demonstrate that 1) the atlas accurately predicts the location of an independent dataset of ventral temporal cortex ROIs and other atlases of place selectivity, motion selectivity, and retinotopy. Next, 2) we show that the majority of voxel within our atlas is responding mostly to the labeled category in a left-out subject cross-validation, demonstrating the utility of this atlas. The functional atlas is publicly available (download.brainvoyager.com/data/visfAtlas.zip) and can help identify the location of these regions in healthy subjects as well as populations (e.g., blind people, infants) in which functional localizers cannot be run.",
+			"citation": "Mona Rosenke, Rick van Hoof, Job van den Hurk, Kalanit Grill-Spector, Rainer Goebel A Probabilistic Functional Atlas of Human Occipito-Temporal Visual Cortex Cerebral Cortex, Volume 31, Issue 1, January 2021, Pages 603-619 https://doi.org/10.1093/cercor/bhaa246"
+		}
+	],
+	"regions": [
+		{
+			"name": "lh_mFus_faces",
+			"rgb": "#ff0000"
+		},
+		{
+			"name": "lh_pFus_faces",
+			"rgb": "#a00000"
+		},
+		{
+			"name": "lh_IOG_faces",
+			"rgb": "#de2d26"
+		},
+		{
+			"name": "lh_OTS_bodies",
+			"rgb": "#00e600"
+		},
+		{
+			"name": "lh_ITG_bodies",
+			"rgb": "#edf8e9"
+		},
+		{
+			"name": "lh_MTG_bodies",
+			"rgb": "#74c476"
+		},
+		{
+			"name": "lh_LOS_bodies",
+			"rgb": "#31a354"
+		},
+		{
+			"name": "lh_pOTS_characters",
+			"rgb": "#090909"
+		},
+		{
+			"name": "lh_IOS_haracters",
+			"rgb": "#edf8e9"
+		},
+		{
+			"name": "lh_CoS_places",
+			"rgb": "#54278f"
+		},
+		{
+			"name": "lh_hMT_motion",
+			"rgb": "#fed976"
+		},
+		{
+			"name": "lh_v1d_retinotopic",
+			"rgb": "#c6dbef"
+		},
+		{
+			"name": "lh_v2d_retinotopic",
+			"rgb": "#9ecae1"
+		},
+		{
+			"name": "lh_v3d_retinotopic",
+			"rgb": "#6baed6"
+		},
+		{
+			"name": "lh_v1v_retinotopic",
+			"rgb": "#4292c6"
+		},
+		{
+			"name": "lh_v2v_retinotopic",
+			"rgb": "#2171b5"
+		},
+		{
+			"name": "lh_v3v_retinotopic",
+			"rgb": "#084594"
+		},
+		{
+			"name": "rh_mFus_faces",
+			"rgb": "#ff0000"
+		},
+		{
+			"name": "rh_pFus_faces ",
+			"rgb": "#a00000"
+		},
+		{
+			"name": "rh_IOG_faces",
+			"rgb": "#de2d26"
+		},
+		{
+			"name": "rh_OTS_bodies",
+			"rgb": "#00e600"
+		},
+		{
+			"name": "rh_ITG_bodies",
+			"rgb": "#edf8e9"
+		},
+		{
+			"name": "rh_MTG_bodies",
+			"rgb": "#74c476"
+		},
+		{
+			"name": "rh_LOS_bodies",
+			"rgb": "#31a354"
+		},
+		{
+			"name": "rh_CoS_places",
+			"rgb": "#54278f"
+		},
+		{
+			"name": "rh_TOS_places",
+			"rgb": "#756bb1"
+		},
+		{
+			"name": "rh_hMT_motion",
+			"rgb": "#fed976"
+		},
+		{
+			"name": "rh_v1d_retinotopic",
+			"rgb": "#c6dbef"
+		},
+		{
+			"name": "rh_v2d_retinotopic",
+			"rgb": "#9ecae1"
+		},
+		{
+			"name": "rh_v3d_retinotopic",
+			"rgb": "#6baed6"
+		},
+		{
+			"name": "rh_v1v_retinotopic",
+			"rgb": "#4292c6"
+		},
+		{
+			"name": "rh_v2v_retinotopic",
+			"rgb": "#2171b5"
+		},
+		{
+			"name": "rh_v3v_retinotopic",
+			"rgb": "#084594"
+		}
+	]
+}


### PR DESCRIPTION
#21
- parcellation
- labelled map on MNI152

Feedback required:
- There is an fsaverage map but it consists of individual '.label's or '.annot' which siibra-python cannot digest. Is this map required? If so, we should make the necessary changes in siibra-python.
- Should this map be available on the explorer? (Need to convert and store accordingly)
